### PR TITLE
Fix bug in 05_Boye_Summary_File_outlier_flag.R that was dropping NA rows

### DIFF
--- a/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
+++ b/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
@@ -327,7 +327,7 @@ combine <- bind_rows(data$data) %>%
   
   # identify fake boye files and then remove them
   mutate(is_fake_boye = str_detect(data_value, "^See_")) %>% 
-  filter(is_fake_boye == FALSE) %>% 
+  filter(is_fake_boye == FALSE | is.na(is_fake_boye)) %>% 
   select(-is_fake_boye) %>% 
   
   # remove text flags


### PR DESCRIPTION
Fixed bug where the code was dropping a sample if all data values were NA. This was happening during the combine step when fake boye files were being detected. Previously it was dropping all files that matched the fake boye format including NA values. The fix means that now it should only remove fake boye files, keeping NA and FALSE. This should now retain all the samples in the summary file. 

Here is an example output of AV1 Water:
![image](https://github.com/user-attachments/assets/cd2b32a8-49ee-43aa-91a6-7f530ee92188)
