### PR TITLE
Fix summary file cannot combine

### DIFF
--- a/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
+++ b/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
@@ -340,6 +340,9 @@ drop_df_columns <- function(df, drop_indices) {
   # fake boye files have text in their data column that starts with "See_"
   # if an igsn column is present in the boye file, it will drop it
 
+# increases threshold for using scientific notation
+options(scipen = 999) # you can check your current scipen value wtih getOption("scipen"); the default is 0 and increasing it reduced the likelihood of scientific notation being used
+
 analyte_files <- list.files(dir, pattern = paste0(material, ".*\\.csv$"), full.names = T) # selects all csv files that contain the word provided in the "material" string
 analyte_files <- analyte_files[!grepl('Mass_Volume',analyte_files)]
 print(basename(analyte_files))

--- a/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
+++ b/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
@@ -14,9 +14,9 @@
 #
 # Author: Brieanne Forbes, brieanne.forbes@pnnl.gov 30 Sept 2022
 #
-# Updated 2025-01-29: Bibi Powers-McCormack, bibi.powers-mccormack@pnnl.gov
+# Updated 2025-02-03: Bibi Powers-McCormack, bibi.powers-mccormack@pnnl.gov
 #
-# Status: in progress 
+# Status: complete 
 
 # INPUTS: 
   # assumptions for the inputs files: 
@@ -184,14 +184,19 @@ combine_data <- function(data) {
       mutate(data_value = as.numeric(data_value)) %>% # data_value col converted to numeric
       select(-is_numeric) %>% 
       ungroup()
+
+    return(combine_df) # returns df
+    
+  } else if (tolower(response) == "n") {
+    
+    warning("The `data_value` column must be numeric. Fix your data and try again.")
+    return(invisible(NULL)) # exits function
     
   } else {
     
-    stop("Script stoping.")
+    stop("The script is stopping due to an issue. Please check your input data and try again.")
     
   }
-  
-  return(combine_df)
   
 } # end of `combine_data()` function
 

--- a/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
+++ b/Data_Package_Documentation/Boye_RF_Formatting/05_Boye_Summary_File_outlier_flag.R
@@ -100,40 +100,40 @@ read_in_files <- function(analyte_files, material) {
       # convert all to chr (temporarily)
       mutate(across(everything(), as.character))
     
-    # extract any values that have letters in them
-    current_file_with_letters <- current_file %>% 
-      select(-any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material",  "Methods_Deviation", "file_name", "user_provided_material"))) %>% 
-      mutate(across(everything(), ~ case_when(str_detect(., "[A-Za-z]") ~ ., TRUE ~ NA))) %>% # shows the user any values that have letters in them
-      pivot_longer(everything()) %>%
-      filter(!is.na(value)) %>%
-      pull(value) %>%
-      unique(.) %>% 
-      unlist()
+    # # extract any values that have letters in them
+    # current_file_with_letters <- current_file %>% 
+    #   select(-any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material",  "Methods_Deviation", "file_name", "user_provided_material"))) %>% 
+    #   mutate(across(everything(), ~ case_when(str_detect(., "[A-Za-z]") ~ ., TRUE ~ NA))) %>% # shows the user any values that have letters in them
+    #   pivot_longer(everything()) %>%
+    #   filter(!is.na(value)) %>%
+    #   pull(value) %>%
+    #   unique(.) %>% 
+    #   unlist()
+    # 
+    # if (length(current_file_with_letters > 0)) {
+    #   
+    #   # show all character data values
+    #   cat("\n", "The above text values will be converted to NA. Okay to proceed?",
+    #       current_file_with_letters %>% 
+    #         cat(., sep = "\n"))
+    #   
+    #   # ask if okay to convert all of those to NA
+    #   response <- readline(prompt = "(Y/N): ")
+    #   
+    # } else {
+    #   response <- "Y"
+    # }
     
-    if (length(current_file_with_letters > 0)) {
-      
-      # show all character data values
-      cat("\n", "The above text values will be converted to NA. Okay to proceed?",
-          current_file_with_letters %>% 
-            cat(., sep = "\n"))
-      
-      # ask if okay to convert all of those to NA
-      response <- readline(prompt = "(Y/N): ")
-      
-    } else {
-      response <- "Y"
-    }
-    
-    # if yes, then convert all to NA
-    if (tolower(response) == "y") {
+    # # if yes, then convert all to NA
+    # if (tolower(response) == "y") {
       
       # then convert all data values to numeric
       current_file <- current_file %>% 
-        mutate(across(!any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material", "Methods_Deviation", "file_name", "user_provided_material")), 
-                      ~ case_when(str_detect(.x, "[A-Za-z]") ~ NA_character_, 
-                                  TRUE ~ .x))) %>% 
-        mutate(across(!any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material", "Methods_Deviation", "file_name", "user_provided_material")), 
-                              ~ as.numeric(.))) %>% 
+        # mutate(across(!any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material", "Methods_Deviation", "file_name", "user_provided_material")), 
+        #               ~ case_when(str_detect(.x, "[A-Za-z]") ~ NA_character_, 
+        #                           TRUE ~ .x))) %>% 
+        # mutate(across(!any_of(c("Sample_Name", "parent_id", "analyte", "rep", "Material", "Methods_Deviation", "file_name", "user_provided_material")), 
+        #                       ~ as.numeric(.))) %>% 
         
         # count number of reps
         group_by(parent_id) %>% 
@@ -156,11 +156,11 @@ read_in_files <- function(analyte_files, material) {
       # add to list
       data_headers[[current_file_name]] <- current_headers
       
-    } else{
-      
-      stop("Script stoping.")
-      
-    }
+    # } else{
+    #   
+    #   stop("Script stoping.")
+    #   
+    # }
     
   }
   


### PR DESCRIPTION
Issue was caused because some data cols were chrs and others num. 

Fixed issue by converting all cols to chr in the `read_in_files()` function. 
Created new `combine_data()` function to check for text cols and have the user confirm the text is okay to remove before it converts the `data_value` col to numeric. 

This is what the user prompt looks like: 
![image](https://github.com/user-attachments/assets/576f4f99-9736-4ca2-809d-265720d5c67b)

(The fake boye files rows are removed and the other text values are converted to NA)