### PR TITLE
Add warning to ess dive download and read data function

### DIFF
--- a/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/README.md
+++ b/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/README.md
@@ -22,15 +22,15 @@ source_url(github_url)
  		- To get the url, you will need to go to the data package on ESS-DIVE, hover over the green download button of the file, zip, or download all button, right click, and select "copy link address". 
 	- `filename` = The filename of the file you want to download from ESS-DIVE. The filename indicates the name of the file as it  will be saved on  your computer, it does not have to match the file name on ESS-DIVE, but we recommend it does for traceability.
 	- `downloads_folder` = Target folder to store the downloaded file
-	- `rm_zip` = Whether to remove the downloaded zip file after unzipped the file, default is FALSE
-	- `rm_unzip_folder`: Whether to remove the unzip_folder after reading data into R, default is FALSE  
+	- `rm_zip` = [Optional] Whether to remove the downloaded zip file after unzipped the file, default is FALSE
+	- `rm_unzip_folder`: [Optional] Whether to remove the unzip_folder after reading data into R, default is FALSE  
 ``` R
 # Example reading in a .zip file. This will download the zip file and load in all the .csv files within the .zip into R
 # Example from Spatial Study 2022: https://data.ess-dive.lbl.gov/view/doi:10.15485/1969566
 csv_files_from_data_package <- download_and_read_data(
 	target_url = "https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-e99c54f68893641-20230824T171850688", # the url from ess-dive
 	filename = "v2_SSS_Data_Package.zip", # your choice for how the downloaded zip will be named
-	downloads_folder = "C:/Users/jdoe123/Downloads")` # the directory the .zip will save to
+	downloads_folder = "C:/Users/jdoe123/Downloads") # the directory the .zip will save to
 ```
 
 5. See [script_ess_dive_file_download_example.R](https://github.com/river-corridors-sfa/rcsfa-essdive-api/blob/main/ESS-DIVE_Download_R/script_ess_dive_file_download_example.R) for more examples on how to use the function.

--- a/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
+++ b/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
@@ -18,6 +18,25 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
   # downloads_folder: target folder to store the downloaded file 
   # rm_zip: whether to remove the downloaded zip file after unzipped the file, default is FALSE
   # rm_unzip_folder: whether to remove the unzip_folder after reading data into R, default is FALSE
+  
+  cat("WARNING: Confirm that the URL you provided is current: \n\n", target_url, 
+      "\n\nIf an outdated URL is provided, it will download an old data package version.\n\nDo you want to proceed?")
+  
+  response <- readline(prompt = "(Y/N): ")
+  
+  if (tolower(response) == "y") {
+
+    
+
+  } else if (tolower(response) == "n") {
+
+    stop("Stopping function.")
+
+  } else {
+
+    stop("ERROR. Stopping function.")
+  }
+  
   existed_files<- list.files(downloads_folder)
   destfile <-file.path(downloads_folder,filename)
   if (!filename %in% existed_files){
@@ -25,7 +44,7 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
     cat("\n")
     curl_download(target_url, destfile =destfile)
   }else{
-    cat( filename,' already in folder')
+    cat( filename,'already in folder. Skipping download. Will read in existing files. ')
     cat("\n")
   }
   # Wait for the download to complete
@@ -63,7 +82,7 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
           cat('unzipping file', destfile)
           cat("\n")
         }else {
-          cat( destfile,' have been unzipped previously')
+          # doing nothing if files have already been unzipped
           cat("\n")
         }
  
@@ -94,6 +113,8 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
       # Print the file names within the folder
       cat("Files and folders in", new_dir, "folder:\n")
       cat(paste0(extracted_files, "\n"), sep = "")
+      cat("\n")
+      cat("Reading in files...")
       cat("\n")
       data_in_file <- list()
       # read the extracted files in folder

--- a/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
+++ b/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
@@ -183,7 +183,7 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
     }
     cat('\n')
     cat('\n')
-    cat("STATUS: The data package has successfully downloaded.")
+    cat("STATUS: download_and_read_data() complete.\nThe data package", filename, "can be found in", downloads_folder)
     cat('\n')
     cat("WARNING: The .csv files have been loaded in, however you may experience parsing issues.")
     cat('\n')

--- a/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
+++ b/Data_Package_ESS-DIVE/download_from_ESS-DIVE_landing_page/ESS-DIVE_Download_R/script_ess_dive_file_download_function.R
@@ -19,8 +19,7 @@ download_and_read_data<-function(target_url,filename,downloads_folder,rm_zip=FAL
   # rm_zip: whether to remove the downloaded zip file after unzipped the file, default is FALSE
   # rm_unzip_folder: whether to remove the unzip_folder after reading data into R, default is FALSE
   
-  cat("WARNING: Confirm that the URL you provided is current: \n\n", target_url, 
-      "\n\nIf an outdated URL is provided, it will download an old data package version.\n\nDo you want to proceed?")
+  cat("WARNING: A newer version of the data package version may be available. \nProviding an outdated URL will result in downloading an older version.\n\nCheck ESS-DIVE for updates before proceeding. Do you want to continue?")
   
   response <- readline(prompt = "(Y/N): ")
   


### PR DESCRIPTION
This is what the new warning looks like in the console: 
![image](https://github.com/user-attachments/assets/9a7be6e4-a742-427d-baf5-b1ed0b35dbe8)

N = the function stops and all that happened was the user got the warning message. 
Y = the function will try to download the file. If the user provided file name matches a folder that already exists in the user provided directory, then the function will skip downloading the file and only attempt to read in the file. If that happens, this is what the console displays: 
![image](https://github.com/user-attachments/assets/5fa6b2d0-afad-48b1-a04d-3a056d8194dc)

After the function has either downloaded the files or skipped the download, it will try to read in the csv files. It will display the column names as it reads the files in. If column names have parsing issues, the console will look like this: 
![image](https://github.com/user-attachments/assets/9d072b75-b2be-4629-892c-0dddfee0a05e)

This is message that display in the console when the function is done: 
![image](https://github.com/user-attachments/assets/795b343f-cf6e-44f1-a0e8-6fd040dca487)
 