### PR TITLE
Fix data checks (v2.0.1)

### DIFF
--- a/Data_Package_Validation/data_package_checks.R
+++ b/Data_Package_Validation/data_package_checks.R
@@ -19,13 +19,13 @@ rm(list=ls(all=T))
 #### REQUIRED ----
 
 # provide the absolute folder file path (do not include "/" at end)
-user_directory <- "C:/Brieanne/GitHub/ECA_DOM_Thermodynamics"
+user_directory <- "C:/Users/powe419/Desktop/bpowers_github_repos/ECA_DOM_Thermodynamics"
 
 # provide the name of the person running the checks
-report_author <- "Brieanne Forbes"
+report_author <- "Bibi Powers-McCormack"
 
 # provide the directory (do not include "/" at the end) for the data package report - the report will be saved as Checks_Report_YYYY-MM-DD.html
-report_out_dir <- "C:/Brieanne/GitHub/ECA_DOM_Thermodynamics"
+report_out_dir <- "C:/Users/powe419/Downloads"
 
 
 # do the tabular files have header rows? (T/F) - header rows that start with "#" can be considered as not having header rows
@@ -58,7 +58,7 @@ flmd_path <- ""
 
 user_exclude_files = c("Map/Map_Input_File.csv",
                        "Map/_readme.txt",
-                       paste0('EC_Data_Package/',list.files("C:/Brieanne/GitHub/ECA_DOM_Thermodynamics/EC_Data_Package", recursive = T)))
+                       paste0('EC_Data_Package/',list.files("C:/Users/powe419/Desktop/bpowers_github_repos/ECA_DOM_Thermodynamics/EC_Data_Package", recursive = T)))
 
 
 # include_files = vector of files (relative file path + file name) to include from within the dir. Optional argument; default is NA_character_. 

--- a/Data_Package_Validation/functions/checks.R
+++ b/Data_Package_Validation/functions/checks.R
@@ -426,6 +426,16 @@ create_range_report <- function(input_df,
   # assumptions
     # currently not set up to handle factors (because those are very R specific and we're assuming data are read in from csv/tsv files)
   
+  # rename any NA or blank columns
+  if (any(is.na(colnames(input_df)) | trimws(colnames(input_df)) == "")) {
+
+    # Find indices of unnamed or blank/whitespace-only column names
+    empty_col_indices <- which(is.na(colnames(input_df)) | trimws(colnames(input_df)) == "")
+
+    # Rename those columns to a placeholder
+    colnames(input_df)[empty_col_indices] <- "EMPTY_COLUMN_HEADER"
+  }
+  
   data_tabular_report <- report_table
   
   # loop through each column in the df
@@ -736,7 +746,7 @@ check_data_package <- function(data_package_data, input_parameters = input_param
       current_df <- data_package_data$tabular_data[[current_file_name_absoulte]]
       
       # update empty col names so the checks and range reports can run - load_tabular_data_from_flmd() reads in csv and tsv files with name_repair = "minimal" so all col headers are read in as they are in the original file
-      if (any(is.na(colnames(current_df)))) {
+      if (any(is.na(colnames(current_df)) | trimws(colnames(current_df)) == "")) {
         
         # find indices of unnamed cols
         empty_col_indices <- which(is.na(colnames(current_df)) | colnames(current_df) == "")

--- a/Data_Package_Validation/functions/test_checks/test-checks.R
+++ b/Data_Package_Validation/functions/test_checks/test-checks.R
@@ -341,7 +341,7 @@ test_that("column type is identified as either character, numeric, logical, Date
   expected <- tibble(
     column_name = c("chr_column", "numeric_column", "logical_column", "date_column", "hms_column", "date_time_column", "mixed_column"),
     column_type = c("character", "numeric", "logical", "Date", "hms", "POSIXct", "mixed"))
-  
+
   expect_equal(object = result, 
                expected = expected)
   
@@ -406,6 +406,43 @@ test_that("numerical min and max ranges are correctly reported", {
   expect_equal(object = result, 
                expected = expected)
   
+})
+
+test_that("range reports generate when a file is missing a column name", {
+  
+  # create example data
+  testing_df <- tibble(
+    date = as.Date(c("2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-07", "2024-01-08", "2024-01-09", "2024-01-10")),
+    time_logged = hms::as_hms(c("12:00:00", "14:30:00", "09:45:00", "11:15:00", "16:00:00", "08:20:00", "13:10:00", "10:40:00", "15:30:00", "17:50:00")),
+    datetime = as.POSIXct(c("2024-01-01 12:00:00", "2024-01-02 14:30:00", "2024-01-03 09:45:00", "2024-01-04 11:15:00", "2024-01-05 16:00:00", "2024-01-06 08:20:00", "2024-01-07 13:10:00", "2024-01-08 10:40:00", "2024-01-09 15:30:00", "2024-01-10 17:50:00")),
+    value1 = c(42, 28, 50, -67, 83, 23, 56, 90, 77, 55),
+    value2 = c(5, 8, 6, 10, 7, 9, 4, 11, 12, 3),
+    value3 = c(0.5, 0.7, 0.3, 0.8, 0.6, 0.9, 0.4, -1.0, 0.2, 0.75),
+    value4 = c(100, -200, 300, 400, 500, 600, 700, 800, 900, 1000),
+    value5 = c(15, 12, 19, 11, 14, 10, 17, 16, 13, 18),
+    value6 = c("GHI", 25, 20, 22, "JKL", 27, -24, 26, "MNO", "MNO"),
+    value7 = c(50, -60, 70, 80, 90, 100, 110, 120, 130, 140)
+  )
+  
+  # remove a col name
+  names(testing_df)[8] <- ""
+  
+  result <- create_range_report(input_df = testing_df,
+                                input_df_name = "testing", 
+                                report_table = initialize_report_df(),
+                                missing_value_codes = input_parameters$missing_value_codes) %>% 
+    select(column_name, range_min, range_max, num_negative_rows)
+  
+  expected <- tibble(
+    column_name = c("date", "time_logged", "datetime", "value1", "value2", "value3", "value4", "EMPTY_COLUMN_HEADER", "value6", "value7"),
+    range_min = c("2024-01-01", "08:20:00", "2024-01-01 12:00:00", -67, 3, -1, -200, 10, -24, -60),
+    range_max = c("2024-01-10", "17:50:00", "2024-01-10 17:50:00", 90, 12, 0.9, 1000, 19, 27, 140),
+    num_negative_rows = c(NA, NA, NA, 1, 0, 1, 1, 0, 1, 1)
+  )
+  
+  expect_equal(object = result, 
+               expected = expected)
+
 })
 
 


### PR DESCRIPTION
Closes #72 

Fixed a bug in the tabular data report where an empty column header was causing the code to error/break. The fix renames empty or NA column headers as “EMPTY_COLUMN_HEADER”; this matches how the rest of the checks handle empty column headers. 

I reran `test-checks.R` and everything passed. I was also able to reproduce the error from the ECA repo and the successfully run data checks after I fixed the code. 

![image](https://github.com/user-attachments/assets/f9ebea95-e247-4b31-9f1a-50ebca5fc149)
![image](https://github.com/user-attachments/assets/813e6636-ced2-457d-a0e9-fa937109e431)
![image](https://github.com/user-attachments/assets/d2dcae72-a0bd-47a7-af26-960ac7332911)
