### PR TITLE
Fix load_tabular_data (v2.1.1)

### DIFF
--- a/Data_Transformation/functions/load_tabular_data.R
+++ b/Data_Transformation/functions/load_tabular_data.R
@@ -407,7 +407,7 @@ load_tabular_data <- function(files_df,
   ### Prep return ##############################################################
   
   # return all data
-  output <- list(inputs = list(directory = abs_directory,
+  output <- list(inputs = list(directory = paste0(abs_directory, parent_directory),
                                files_df = files_df,
                                flmd_df = flmd_df),
                  outputs = list(header_row_info = tabular_metadata,


### PR DESCRIPTION
Closes #74 

I had to change one line of code in the load_tabular_data() function.

The data checks now looks like this: 
![image](https://github.com/user-attachments/assets/5f57cd7f-e431-48c5-813b-088ca24f5574)
And the directory tree correctly includes only the given directory (not the parent dir):
![image](https://github.com/user-attachments/assets/0226027c-8e20-4c36-91c9-12c605bd259a)
